### PR TITLE
Allow for 7 (instead of 8) columns per row

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,12 +97,17 @@ func sel2item(s *goquery.Selection) (*item, error) {
 		ss = append(ss, trimText(s.Text()))
 	})
 
+	// Generally, we expect 8 columns. However, for some rows, the last column (info) is missing, so we add an empty string
 	if got, want := len(ss), 8; got != want {
-		details, err := s.Html()
-		if err != nil {
-			details = err.Error()
+		if got == 7 {
+			ss = append(ss, "") // Add empty string for missing info
+		} else {
+			details, err := s.Html()
+			if err != nil {
+				details = err.Error()
+			}
+			return nil, fmt.Errorf("invalid number of parts found %d/%d: %s", got, want, details)
 		}
-		return nil, fmt.Errorf("invalid number of parts found %d/%d: %s", got, want, details)
 	}
 
 	for i, s := range ss {


### PR DESCRIPTION
The current version fails with an error:
"invalid number of parts found 7/8" for the table row "Karlsruhe, Land / 07.01.2025 / Bäckerei Misch / ...".
And indeed, this row is missing the last column (on the website, the last column is just empty).

=> my PR makes "sel2item" a bit more flexible by allowing for 7 instead of 8 columns, and just appending an empty string if only 7 columns are encountered. 