### PR TITLE
chore(deps): add Nix support to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+  - package-ecosystem: "nix" # zizmor: ignore[dependabot-cooldown] We want the latest and greatest
+    directory: "/"
+    schedule:
+      interval: "daily"
   - package-ecosystem: "gomod" # zizmor: ignore[dependabot-cooldown] We want the latest and greatest
     directory: "/"
     schedule:


### PR DESCRIPTION
Nix-support in Dependabot was (finally!) added today: https://github.blog/changelog/2026-04-07-dependabot-version-updates-now-support-the-nix-ecosystem/